### PR TITLE
Add issue template and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+* **I'm submitting a ...**
+  - [ ] bug report
+  - [ ] feature request
+  - [ ] doc update
+
+* **What is the current status?**
+
+
+
+* **If the current behaviour is a bug, please provide the steps to reproduce it**
+> A screenshot of the issue may be sufficient for UI bugs
+
+
+
+* **What is the expected behaviour?**
+
+
+
+* **Please tell us about your environment:**
+  - OS with version number: [ Windows / OSX / Linux Distro ]
+
+
+* **Other information** ( Any research that you may have done which you think is the cause of problem )
+
+
+* **Would you like to work on it?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+* **Please check if the PR fulfills these requirements**
+- [ ] The commit message follows our guidelines
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+
+* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+- [ ] Bug fix
+- [ ] Feature implementation
+- [ ] Doc updates
+
+* **Related Issue**
+<!-- Please provide the reference to the issue you are fixing-->
+
+
+* **What changes have you introduced?**
+
+
+
+* **Does this PR introduce a breaking change?**
+
+
+
+* **Preview / Steps to verify your work**:


### PR DESCRIPTION
Fixes #38 
Issue: PR and issue templates were missing from this repo.

I have added an issue template and a PR template in .github folder.

To verify you can check in .github folder in the root of the repository.  


