### PR TITLE
Revert "Switch back to env var `GITHUB_API_KEY` for deployment"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 deploy:
   provider: pages
   skip_cleanup: true
-  github_token: $GITHUB_API_KEY
+  github_token: $GITHUB_TOKEN
   keep_history: true
   on:
     all_branches: true


### PR DESCRIPTION
Travis is behaving strange; see its build history. It looks like old env vars had been lingering around and suddenly reverted back and now reverted again. :confused: 

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Doc updates

* **Related Issue**
<!-- Please provide the reference to the issue you are fixing-->


* **What changes have you introduced?**



* **Does this PR introduce a breaking change?**



* **Preview / Steps to verify your work**:
