### PR TITLE
Add note for legacy Windows systems

### DIFF
--- a/python-library/index.md
+++ b/python-library/index.md
@@ -5,3 +5,8 @@ The PSLab Python library provides programmatic access to PSLab boards on PCs.
 It is also the backend to the [PSLab desktop app](../desktop/Readme.html).
 
 The sources are on [GitHub](http://github.com/fossasia/pslab-python).
+
+**Note for older Windows systems**
+
+PSLab is using an MCP2200 USB serial adapter. You may need to install the driver
+from the [Microchip website](https://www.microchip.com/wwwproducts/en/en546923).


### PR DESCRIPTION
Based on [this tweet](https://twitter.com/urbatecte1/status/1295422543030104067), people might have issues on older Windows systems. The suggested solution may or may not work; let's wait for a reply and then merge.

If anyone else has a PSLab device and is running an older version of Windows, please leave your feedback here. Thank you! :)