### PR TITLE
fix: Reworded the File Formats section in collaborate/Readme.md: only

### DIFF
--- a/collaborate/Readme.md
+++ b/collaborate/Readme.md
@@ -17,11 +17,15 @@ One of the best ways to contribute to PSLab is by creating experiments. These ex
 
 We primarily use Markdown (.md) for our documentation. However, please note:
 
-- The main document headlines (typically the first one at the top of the file) should be written in reStructuredText (ReST) format for compatibility with Sphinx documentation.
-- The rest of the content should be in Markdown format.
+- The main document title (the first headline at the top of the file) should be underlined instead of using a `#`, e.g.:
 
-For convenience, you can use [notex](https://www.notex.ch), an
-[open-source](https://github.com/hsk81/notex-v2.0) ReST editor.
+  ```
+  Title
+  =====
+  ```
+
+  This keeps the title compatible with Sphinx, and is still valid Markdown. See `tutorials/template.md` for an example.
+- Everything else, including subheadings and remarks (e.g. `> Note: ...`), should be written in plain Markdown.
 
 ## Editing Tools
 


### PR DESCRIPTION
Fixes #114

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Doc updates

* **Related Issue**
<!-- Please provide the reference to the issue you are fixing-->


* **What changes have you introduced?**



* **Does this PR introduce a breaking change?**



* **Preview / Steps to verify your work**:

---

Reworded the File Formats section in collaborate/Readme.md: only the top document title needs the underlined (setext) heading style for Sphinx, which is still valid Markdown, so the misleading 'ReST format'/notex-editor guidance was replaced; also clarified that remarks like `> Note: ...` follow plain Markdown blockquote style, matching actual usage elsewhere in the docs (e.g. tutorials/compass.md).

**How this was tested:** `the affected tests`

## Summary by Sourcery

Documentation:
- Explain that only the main document title should use an underlined setext-style heading compatible with Sphinx, with the rest of the content in plain Markdown including subheadings and note blockquotes.